### PR TITLE
Fixes for USBSID-Pico

### DIFF
--- a/deps/USBSID-Pico/USBSID.cpp
+++ b/deps/USBSID-Pico/USBSID.cpp
@@ -855,6 +855,8 @@ void USBSID_Class::USBSID_DisableThread(void)
 void USBSID_Class::USBSID_ResetRingBuffer(void)
 {
   us_ringbuffer.ring_read = us_ringbuffer.ring_write = 0;
+  buffer_pos = 1;
+  flush_buffer = 0;
   return;
 }
 
@@ -965,8 +967,45 @@ void USBSID_Class::USBSID_SetFlush(void)
 
 void USBSID_Class::USBSID_FlushBuffer(void)
 {
-  if (threaded && flush_buffer == 1
-    && ((withcycles == 1)
+  if (!threaded || flush_buffer != 1) {
+    flush_buffer = 0;
+    return;
+  }
+
+  /* The flush is a deadline, so whatever is still waiting in the ring belongs
+   * in this packet.
+   *
+   * Without this the ring is only ever drained by USBSID_Thread(), which stops
+   * while fewer than diff_size bytes are waiting, and a packet only goes out
+   * once it reaches 61 bytes on withcycles. A write therefore waits behind up to
+   * 15 + (diff_size / 4) writes, and what that costs is a time that moves with
+   * how fast the caller happens to be writing: about 2 ms during a volume
+   * register digi at ten thousand writes a second, and a quarter of a second
+   * once the sample ends and an ordinary tune writes its registers once a
+   * frame. Ghostbusters.sid is both in turn, and the notes after its speech
+   * arrived up to 229 ms late. No value of diff_size fixes that, because the
+   * 15 writes sitting in the packet are not diff_size's to give back.
+   *
+   * The fill is worked out here rather than with USBSID_RingDiff(), which
+   * returns the free space instead of the fill once ring_read has passed
+   * ring_write.
+   *
+   * The loop always consumes a whole record or exits, so it cannot spin. The
+   * thread's own drain loop and diff_size are deliberately left alone: leaving
+   * that loop is the only thing that reaches libusb_handle_events(), and a
+   * drain condition that cannot be satisfied hangs playback outright. */
+  const int rec = (withcycles == 1) ? 4 : 2;
+  const int cap = (withcycles == 1) ? 61 : 63;
+  int waiting = (us_ringbuffer.ring_write - us_ringbuffer.ring_read
+                 + ring_size) % ring_size;
+  while (waiting >= rec && (buffer_pos + rec) <= cap) {
+    for (int i = 0; i < rec; i++) {
+      thread_buffer[buffer_pos++] = USBSID_RingGet();
+    }
+    waiting -= rec;
+  }
+
+  if (((withcycles == 1)
     ? (buffer_pos >= 5)
     : (buffer_pos >= 3))) {
     thread_buffer[0] = (withcycles == 1)

--- a/deps/USBSID-Pico/USBSID.h
+++ b/deps/USBSID-Pico/USBSID.h
@@ -381,7 +381,6 @@ namespace USBSID_NS
       pthread_t us_ptid;
 
       /* Ringbuffer */
-      void USBSID_ResetRingBuffer(void);
       void USBSID_InitRingBuffer(int buffer_size, int differ_size);
       void USBSID_InitRingBuffer(void);
       void USBSID_DeInitRingBuffer(void);
@@ -462,6 +461,7 @@ namespace USBSID_NS
       void USBSID_Flush(void);                                                 /* Set flush buffer flag to 1 and flushes the buffer */
       void USBSID_SetBufferSize(int size);                                     /* Set the buffer size for storing writes */
       void USBSID_SetDiffSize(int size);                                       /* Set the minimum size difference between head & tail */
+      void USBSID_ResetRingBuffer(void);                                       /* Resets the ringbuffer to default state */
       void USBSID_RestartRingBuffer(void);                                     /* Restart the ringbuffer */
 
       /* Thread utils */

--- a/emulation/libc64/system/usbSidPico.cpp
+++ b/emulation/libc64/system/usbSidPico.cpp
@@ -13,9 +13,14 @@ namespace LIBC64 {
 USBSIDPico::USBSIDPico(System& system) : system(system), sysTimer(system.sysTimer) {
 #ifdef LIBUSB
     flush = [this]() {
-        usbsid->USBSID_SetFlush();
-        lastClock = sysTimer.clock;
-        this->sysTimer.add( &flush, rasterRate, Emulator::SystemTimer::UpdateExisting );
+        unsigned cycles = sysTimer.clock - lastClock;
+        if (cycles < rasterRate) {
+            this->sysTimer.add( &flush, rasterRate, Emulator::SystemTimer::UpdateExisting );
+        } else {
+            lastClock += cycles;
+            usbsid->USBSID_Flush();
+            this->sysTimer.add( &flush, rasterRate, Emulator::SystemTimer::UpdateExisting );
+        }
     };
 
 #else
@@ -41,6 +46,8 @@ auto USBSIDPico::open() -> int {
         }
         result = 1;
     } else {
+        usbsid->USBSID_ResetRingBuffer();
+        usbsid->USBSID_ResetAllRegisters();
         usbsid->USBSID_Reset();
         result = 2;
     }
@@ -56,58 +63,61 @@ auto USBSIDPico::open() -> int {
 }
 
 auto USBSIDPico::close() -> void {
-#ifdef LIBUSB    
+#ifdef LIBUSB
     if (usbsid) {
         sysTimer.remove(&flush);
         usbsid->USBSID_Mute();
         delete usbsid;  /* Executes usbsid->USBSID_Close(); */
     }
-#endif    
+#endif
 }
 
 auto USBSIDPico::setBuffSize(unsigned value) -> void {
-#ifdef LIBUSB    
+#ifdef LIBUSB
     if (!usbsid || (value == buffSize))
         return;
 
     buffSize = value;
     usbsid->USBSID_SetBufferSize(buffSize);
     usbsid->USBSID_RestartRingBuffer();
-#endif    
+#endif
 }
 
 auto USBSIDPico::setDiffSize(unsigned value) -> void {
-#ifdef LIBUSB    
+#ifdef LIBUSB
     if (!usbsid || (value == diffSize))
         return;
 
     diffSize = value;
     usbsid->USBSID_SetDiffSize(diffSize);
-#endif    
+#endif
 }
 
 auto USBSIDPico::store(uint8_t addr, uint8_t val, int chipNr) -> void {
-#ifdef LIBUSB    
-    unsigned cycles = sysTimer.fallBackCycles(lastClock);
-    cycles = (cycles > 0) ? (cycles - 1) : cycles;
+#ifdef LIBUSB
+    unsigned cycles = (sysTimer.clock - lastClock);
+    cycles = ((cycles > 0) ? (cycles - 1) : cycles);
     if (usbsid)
         usbsid->USBSID_WriteRingCycled(addr + (chipNr * 0x20), val, cycles);
     lastClock = sysTimer.clock;
-#endif    
+#endif
 }
 
 auto USBSIDPico::reset() -> void {
-#ifdef LIBUSB    
+#ifdef LIBUSB
     if (usbsid)
+        usbsid->USBSID_ResetRingBuffer();
+        usbsid->USBSID_ResetAllRegisters();
         usbsid->USBSID_Reset();
-#endif        
+        usbsid->USBSID_UnMute();
+#endif
 }
 
 auto USBSIDPico::updateStereo() -> void {
-#ifdef LIBUSB    
+#ifdef LIBUSB
     if (usbsid)
         usbsid->USBSID_SetStereo(system.interface->stats.stereoSound);
-#endif        
+#endif
 }
 
 auto USBSIDPico::serialize(Emulator::Serializer& s) -> void {
@@ -127,7 +137,7 @@ auto USBSIDPico::serialize(Emulator::Serializer& s) -> void {
             }
         }
     }
-#endif    
+#endif
 }
 
 }


### PR DESCRIPTION
- Fix premature buffer flush issue
- Make resetringbuffer public
- Rework cycle count in driver code (fixes crackle in cycle exact tunes)